### PR TITLE
fix: deep-copy the response object to prevent mutability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubric/featuregates",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Firestore backed feature gates",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,9 @@ export default class FeatureGates {
           return acc;
         }, {});
     }
-    return this.featureGates;
+
+    // deep-copy the response object to prevent mutability to original object in use
+    return JSON.parse(JSON.stringify(this.featureGates));
   }
 
   set(gates, shouldTranslate = true) {

--- a/tests/immutable.test.js
+++ b/tests/immutable.test.js
@@ -1,0 +1,61 @@
+import "@babel/polyfill";
+import FeatureGates from '../src/index';
+
+const dummyFGs = {
+    secret: {
+        admins: [
+            'test@doma.in',
+            'user@example.com',
+        ],
+        internalDomains: [
+            'doma.in',
+            'example.com'
+        ],
+    },
+    other: {
+        testers: {
+            hi: "there"
+        }
+    }
+};
+
+let fg;
+beforeEach(() => {
+    fg = new FeatureGates({
+        gates: dummyFGs,
+        path: 'test',
+        translateMap: {
+            admins: "secret.admins",
+            internalDomains: 'secret.internalDomains',
+            testValues: "other.testers.hi",
+        }
+    });
+    fg.load();
+});
+
+describe('Immutability tests', () => {
+    it('should get back the resolved feature-gates without any effect on key deletion', () => {
+        return expect(
+            (() => {
+                const featureGates = fg.get();
+
+                // deleting these keys should not affect the reference object as the response
+                // of get() method is a deep-copy version of the original object
+                delete featureGates.admins;
+                delete featureGates.internalDomains;
+
+                return fg.get();
+            })()
+        ).toEqual({
+            admins: [
+                'test@doma.in',
+                'user@example.com',
+            ],
+            internalDomains: [
+                'doma.in',
+                'example.com'
+            ],
+            testValues: "there"
+        })
+    })
+})


### PR DESCRIPTION
mutating the response object now changes the internally used object too. This PR fixes that by creating a deep-copy of the object which is sent as the response object

Signed-off-by: Abhijith Vijayan [KUBRIC] <78354201+abhijith-vijayan@users.noreply.github.com>